### PR TITLE
Refactor/create is runtime platform extension

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,21 +28,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -63,21 +56,21 @@ packages:
       name: equatable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -108,28 +101,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   platform:
     dependency: transitive
     description:
@@ -155,7 +148,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -176,21 +169,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/adaptive/adaptive_test.dart
+++ b/lib/src/adaptive/adaptive_test.dart
@@ -1,16 +1,16 @@
 import 'dart:io';
 
-import 'package:adaptive_test/src/configuration.dart';
-import 'package:flutter/foundation.dart';
 import 'package:adaptive_test/src/adaptive/window_configuration.dart';
-import 'package:adaptive_test/src/helpers/await_images.dart';
-import 'package:flutter_test/flutter_test.dart';
-
-import 'package:flutter/material.dart';
 import 'package:adaptive_test/src/adaptive/window_size.dart';
+import 'package:adaptive_test/src/configuration.dart';
+import 'package:adaptive_test/src/helpers/await_images.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
 import 'package:recase/recase.dart';
 
+import '../helpers/target_platform_extension.dart';
 import 'widgets/adaptive_wrapper.dart';
 
 /// Type of [callback] that will be executed inside the Flutter test environment.
@@ -73,7 +73,7 @@ extension Adaptive on WidgetTester {
     final enforcedTestPlatform =
         AdaptiveTestConfiguration.instance.enforcedTestPlatform;
     if (enforcedTestPlatform != null &&
-        Platform.operatingSystem != enforcedTestPlatform.name.toLowerCase()) {
+        enforcedTestPlatform.isRuntimePlatform) {
       throw ('Runtime platform ${Platform.operatingSystem} is not ${enforcedTestPlatform.name}');
     }
 

--- a/lib/src/helpers/target_platform_extension.dart
+++ b/lib/src/helpers/target_platform_extension.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -5,20 +6,37 @@ import 'package:meta/meta.dart';
 
 @internal
 extension IsRuntimePlatform on TargetPlatform {
+  void _logUnusualTargetPlatformWarning() {
+    final usualTargetPlatforms = [
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+      TargetPlatform.windows
+    ];
+
+    if (usualTargetPlatforms.contains(this)) {
+      return;
+    } else {
+      log('''Tests are intended to be runned on linux, macOS or windows platform.
+      But you are running them on $name''');
+    }
+  }
+
   bool get isRuntimePlatform {
+    _logUnusualTargetPlatformWarning();
+
     switch (this) {
-      case TargetPlatform.android:
-        return Platform.isAndroid;
-      case TargetPlatform.fuchsia:
-        return Platform.isFuchsia;
-      case TargetPlatform.iOS:
-        return Platform.isIOS;
       case TargetPlatform.linux:
         return Platform.isLinux;
       case TargetPlatform.macOS:
         return Platform.isMacOS;
       case TargetPlatform.windows:
         return Platform.isWindows;
+      case TargetPlatform.android:
+        return Platform.isAndroid;
+      case TargetPlatform.fuchsia:
+        return Platform.isFuchsia;
+      case TargetPlatform.iOS:
+        return Platform.isIOS;
     }
   }
 }

--- a/lib/src/helpers/target_platform_extension.dart
+++ b/lib/src/helpers/target_platform_extension.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
+
+@internal
+extension IsRuntimePlatform on TargetPlatform {
+  bool get isRuntimePlatform {
+    switch (this) {
+      case TargetPlatform.android:
+        return Platform.isAndroid;
+      case TargetPlatform.fuchsia:
+        return Platform.isFuchsia;
+      case TargetPlatform.iOS:
+        return Platform.isIOS;
+      case TargetPlatform.linux:
+        return Platform.isLinux;
+      case TargetPlatform.macOS:
+        return Platform.isMacOS;
+      case TargetPlatform.windows:
+        return Platform.isWindows;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,18 +10,18 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  cupertino_icons: ^1.0.5
+  equatable: ^2.0.5
+  file: ^6.1.4
   flutter:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  path: ^1.8.1
-  test_api: ^0.4.9
-  meta: ^1.7.0
-  cupertino_icons: ^1.0.4
-  recase: ^4.0.0
-  equatable: ^2.0.3
-  file: ^6.1.2
+  meta: ^1.8.0
+  path: ^1.8.2
   platform: ^3.1.0
+  recase: ^4.0.0
+  test_api: ^0.4.12
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
Pull request to change the way we compare Runtime and Target platform

The operatingSystem getter on Runtime platform can change with time and nothing will warn us in the code
By using the isAndoid, isIOS, etc... getter, we ensure that this comparaison will always work