### PR TITLE
feat(golden): add an option to not precache images in a golden test

### DIFF
--- a/lib/src/adaptive/adaptive_test.dart
+++ b/lib/src/adaptive/adaptive_test.dart
@@ -69,6 +69,7 @@ extension Adaptive on WidgetTester {
     String? suffix,
     Key?
         byKey, // Sometimes we want to find the widget by its unique key in the case they are multiple of the same type.
+    bool waitForImages = false,
   }) async {
     final enforcedTestPlatform =
         AdaptiveTestConfiguration.instance.enforcedTestPlatform;
@@ -80,7 +81,9 @@ extension Adaptive on WidgetTester {
     final localSuffix = suffix != null ? "_${ReCase(suffix).snakeCase}" : '';
 
     final name = ReCase('$T');
-    await awaitImages();
+    if (waitForImages) {
+      await awaitImages();
+    }
     await expectLater(
       // Find by its type except if the widget's unique key was given.
       byKey != null ? find.byKey(byKey) : find.byType(AdaptiveWrapper),


### PR DESCRIPTION
Adding this option so the dev can choose wether the `awaitImages` callback should be called or not