### PR TITLE
changed separator in golden file name

### DIFF
--- a/lib/src/adaptive/adaptive_test.dart
+++ b/lib/src/adaptive/adaptive_test.dart
@@ -88,7 +88,7 @@ extension Adaptive on WidgetTester {
       // Find by its type except if the widget's unique key was given.
       byKey != null ? find.byKey(byKey) : find.byType(AdaptiveWrapper),
       matchesGoldenFile(
-        'preview/${windowConfig.name}:${name.snakeCase}$localSuffix.png',
+        'preview/${windowConfig.name}_${name.snakeCase}$localSuffix.png',
       ),
     );
   }


### PR DESCRIPTION
Current colon separator is an invalid character in windows file names. Windows users cannot clone repo that contains golden files with ":" separator.

also files in the example app needs to be regenerated