### PR TITLE
feat: add support for skipping tests based on the enforced target platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+* feat: add support for skipping tests instead of failing them based on the enforced target platform defined in the `AdaptiveTestConfiguration` class.
+
 ## 0.5.0
 
 **Breaking changes**

--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
 
 As an alternative you can use [Alchemist](https://pub.dev/packages/alchemist).
 
+Also, you can configure `AdaptiveTestConfiguration` singleton to skip tests instead of throwing if they are run on an unintended platform.
+```dart
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  AdaptiveTestConfiguration.instance
+    ..setEnforcedTestPlatform(TargetPlatform.macOS)
+    ..setFailTestOnWrongPlatform(false) <-- Adding this will skip the `testAdaptiveWidgets` tests if you are not running the tests on a macOS platform.
+    ..setDeviceVariants(defaultDeviceConfigs);
+  await loadFonts();
+  setupFileComparatorWithThreshold();
+  await testMain();
+}
+```
+
 ### Write a test
 Use `testAdaptiveWidgets` function. It take a callback with two arguments, `WidgetTester` and `WindowConfigData`.
 

--- a/lib/adaptive_test.dart
+++ b/lib/adaptive_test.dart
@@ -1,9 +1,9 @@
+export 'src/adaptive/adaptive_test.dart';
+export 'src/adaptive/devices_data.dart';
+export 'src/adaptive/widgets/adaptive_wrapper.dart';
+export 'src/adaptive/window_configuration.dart';
+export 'src/adaptive/window_size.dart';
+export 'src/configuration.dart';
 export 'src/helpers/await_images.dart';
 export 'src/helpers/fonts_loader.dart';
 export 'src/helpers/goldens_difference.dart';
-export 'src/adaptive/adaptive_test.dart';
-export 'src/adaptive/window_size.dart';
-export 'src/adaptive/window_configuration.dart';
-export 'src/adaptive/devices_data.dart';
-export 'src/adaptive/widgets/adaptive_wrapper.dart';
-export 'src/configuration.dart';

--- a/lib/adaptive_test.dart
+++ b/lib/adaptive_test.dart
@@ -7,3 +7,4 @@ export 'src/configuration.dart';
 export 'src/helpers/await_images.dart';
 export 'src/helpers/fonts_loader.dart';
 export 'src/helpers/goldens_difference.dart';
+export 'src/helpers/skip_test_extension.dart';

--- a/lib/src/adaptive/adaptive_test.dart
+++ b/lib/src/adaptive/adaptive_test.dart
@@ -4,6 +4,7 @@ import 'package:adaptive_test/src/adaptive/window_configuration.dart';
 import 'package:adaptive_test/src/adaptive/window_size.dart';
 import 'package:adaptive_test/src/configuration.dart';
 import 'package:adaptive_test/src/helpers/await_images.dart';
+import 'package:adaptive_test/src/helpers/skip_test_extension.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -27,14 +28,22 @@ typedef WidgetTesterAdaptiveCallback = Future<void> Function(
 void testAdaptiveWidgets(
   String description,
   WidgetTesterAdaptiveCallback callback, {
+  /// If true, the test will be skipped. Defaults to false.
+  /// If [enforcedTestPlatform] is defined in the [AdaptiveTestConfiguration]
+  /// and [failTestOnWrongPlatform] is false, the test will be skipped if the
+  /// runtime platform does not match the [enforcedTestPlatform].
   bool? skip,
   Timeout? timeout,
   bool semanticsEnabled = true,
   ValueVariant<WindowConfigData>? variantOverride,
   dynamic tags,
 }) {
-  final defaultVariant = AdaptiveTestConfiguration.instance.deviceVariant;
+  final configuration = AdaptiveTestConfiguration.instance;
+  final defaultVariant = configuration.deviceVariant;
   final variant = variantOverride ?? defaultVariant;
+
+  skip = skip ?? configuration.shouldSkipTest;
+
   testWidgets(
     description,
     (tester) async {

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -34,6 +34,20 @@ class AdaptiveTestConfiguration {
     _enforcedTestPlatform = enforcedTestPlatform;
   }
 
+  bool _failTestOnWrongPlatform = true;
+
+  bool get failTestOnWrongPlatform => _failTestOnWrongPlatform;
+
+  /// When using [enforcedTestPlatform], the default behavior is that the test
+  /// will fail if the runtime platform the test is running on does not match
+  /// the [enforcedTestPlatform].
+  ///
+  /// Setting [failTestOnWrongPlatform] to false will skip the test instead of
+  /// failing it.
+  void setFailTestOnWrongPlatform(bool failTestOnWrongPlatform) {
+    _failTestOnWrongPlatform = failTestOnWrongPlatform;
+  }
+
   WindowVariant? _deviceVariant;
 
   WindowVariant get deviceVariant {

--- a/lib/src/helpers/skip_test_extension.dart
+++ b/lib/src/helpers/skip_test_extension.dart
@@ -1,0 +1,26 @@
+import 'package:adaptive_test/adaptive_test.dart';
+import 'package:adaptive_test/src/helpers/target_platform_extension.dart';
+
+/// Extension on [AdaptiveTestConfiguration] to determine if a test should be
+/// skipped based on the [AdaptiveTestConfiguration.enforcedTestPlatform] and
+/// [AdaptiveTestConfiguration.failTestOnWrongPlatform] values.
+extension ShouldSkipAdaptiveTest on AdaptiveTestConfiguration {
+  /// If [AdaptiveTestConfiguration.enforcedTestPlatform] is defined and the
+  /// runtime platform does not match the enforced platform, the test will be
+  /// skipped if [AdaptiveTestConfiguration.failTestOnWrongPlatform] is false.
+  ///
+  /// This extension is used to determine if a test should be skipped based on the
+  /// [AdaptiveTestConfiguration.enforcedTestPlatform] and
+  /// [AdaptiveTestConfiguration.failTestOnWrongPlatform] values.
+  bool get shouldSkipTest {
+    final configuration = AdaptiveTestConfiguration.instance;
+    final enforcedTestPlatform = configuration.enforcedTestPlatform;
+
+    if (enforcedTestPlatform != null &&
+        !enforcedTestPlatform.isRuntimePlatform) {
+      return !configuration.failTestOnWrongPlatform;
+    }
+
+    return false;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: adaptive_test
 description: >-
   A Flutter package to generate adaptive golden files during widget tests.
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/bamlab/adaptive_test
 repository: https://github.com/bamlab/adaptive_test
 
 environment:
-  sdk: '>=3.0.5 <4.0.0'
+  sdk: ">=3.0.5 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
Add support for skipping tests instead of failing them based on the enforced target platform defined in the `AdaptiveTestConfiguration` class.

```dart
Future<void> testExecutable(FutureOr<void> Function() testMain) async {
  TestWidgetsFlutterBinding.ensureInitialized();
  AdaptiveTestConfiguration.instance
    ..setSkippedTestPlatform(TargetPlatform.macOS)
    ..setFailTestOnWrontPlatform(false) <-- Adding this will skip the `testAdaptiveWidgets` tests if you are not running the tests on a macOS platform.
    ..setDeviceVariants(defaultDeviceConfigs);
  await loadFonts();
  setupFileComparatorWithThreshold();
  await testMain();
}
```