### PR TITLE
Support `ShapeDecoration` in widget image precaching for tests

### DIFF
--- a/lib/src/helpers/await_images.dart
+++ b/lib/src/helpers/await_images.dart
@@ -30,12 +30,14 @@ extension AwaitImages on WidgetTester {
       for (final element in find.byType(DecoratedBox).evaluate().toList()) {
         final widget = element.widget as DecoratedBox;
         final decoration = widget.decoration;
-        if (decoration is BoxDecoration) {
-          final image = decoration.image?.image;
-          if (image != null) {
-            await precacheImage(image, element);
-            await pump();
-          }
+        final image = switch (decoration) {
+          BoxDecoration() => decoration.image?.image,
+          ShapeDecoration() => decoration.image?.image,
+          _ => null,
+        };
+        if (image != null) {
+          await precacheImage(image, element);
+          await pump();
         }
       }
     });


### PR DESCRIPTION
## 📝 Description

This pull request improves the image precaching mechanism in widget tests by adding support for `ShapeDecoration`.

Previously, only `BoxDecoration` was checked when attempting to extract and precache background images in decorated widgets. However, `ShapeDecoration` can also contain images through its `image` property.

---

## ✅ Changes

Affected file : `await_images.dart`
- Replaced the `if (decoration is BoxDecoration)` check with a `switch` expression to handle multiple decoration types.
- Added support for extracting images from `ShapeDecoration`.
- Defaulted to `null` when the decoration type is not handled or contains no image.

---

## 🧪 Motivation

Some widgets use `ShapeDecoration` instead of `BoxDecoration` to apply background images. Without this change, those images were not detected and precached during widget tests, potentially leading to rendering issues or test flakiness.

By extending support to `ShapeDecoration`, this PR ensures that **all relevant images are properly precached**, improving the reliability and coverage of widget tests.